### PR TITLE
avoid deprecated syntax

### DIFF
--- a/src/PHPOpenLDAPer/LDAPConn.php
+++ b/src/PHPOpenLDAPer/LDAPConn.php
@@ -86,7 +86,7 @@ class LDAPConn
     {
         if (is_array($arr)) {
             unset($arr['count']);
-            array_walk($arr, "self::stripCount");
+            array_walk($arr, [self::class, "stripCount"]);
         }
     }
 }


### PR DESCRIPTION
[use of self in callables is deprecated](https://php.watch/versions/8.2/partially-supported-callable-deprecation)