### PR TITLE
use empty array when attribute is null

### DIFF
--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -334,7 +334,7 @@ class LDAPEntry
         if (isset($this->object[$attr])) {
             return $this->object[$attr];
         } else {
-            return null;
+            return [];
         }
     }
 


### PR DESCRIPTION
the only reason I can think of not to default to `[]` is that it wouldn't be intuitive for non array values, but we are already doing `getAttribute("cn")[0]`, so non array values are already returned as arrays. https://github.com/search?q=repo%3AUnityHPC%2Funity-web-portal+getAttribute+%22%5B0%5D%22&type=code