### PR TITLE
prevent duplicate LDAPEntries

### DIFF
--- a/src/PHPOpenLDAPer/LDAPConn.php
+++ b/src/PHPOpenLDAPer/LDAPConn.php
@@ -14,6 +14,7 @@ namespace PHPOpenLDAPer;
 class LDAPConn
 {
     protected $conn;  // LDAP link
+    private $entries = [];
 
   /**
    * Constructor, starts an ldap connection and binds to a DN
@@ -67,14 +68,20 @@ class LDAPConn
     }
 
   /**
-   * Gets a single entry from the LDAP server
+   * Gets a single entry from the LDAP server. If multiple calls are made for the same DN,
+   * subsequent calls will return the same object as the first call.
    *
    * @param string $dn Distinguished name (DN) of requested entry
    * @return ldapEntry requested entry object
    */
-    public function getEntry($dn)
+    public function getEntry(string $dn): LDAPEntry
     {
-        return new LDAPEntry($this->conn, $dn);
+        if (array_key_exists($dn, $this->entries)) {
+            return $this->entries[$dn];
+        }
+        $entry = new LDAPEntry($this->getConn(), $dn);
+        $this->entries[$dn] = $entry;
+        return $entry;
     }
 
   /**


### PR DESCRIPTION
while writing tests for disbanding and recreating PI accounts I ran into an issue where I had multiple LDAPEntry objects representing the same PI group, and after calling LDAPEntry->delete(), the other object had a stale value in $this->object, so $this->exists() returned true even though it should have been false. Making the LDAPEntries unique is much more efficient than making every write operation do an extra `ldap_search` to refresh the value of `$this->object` and `this->exists()`