### PR TITLE
rewrite `pullObject`

### DIFF
--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -40,6 +40,7 @@ class LDAPEntry
     {
         $result = @ldap_read($this->conn, $this->dn, "(objectclass=*)");
         if ($result === false) {
+            $this->object = null;
             return false;
         }
         $search = @ldap_get_entries($this->conn, $result);

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -35,6 +35,7 @@ class LDAPEntry
 
   /**
    * Pulls an entry from the ldap connection, and sets $object If entry does not exist, $object = null.
+   * @returns bool existence of ldap object
    */
     private function pullObject()
     {
@@ -43,17 +44,17 @@ class LDAPEntry
             $this->object = null;
             return false;
         }
-        $search = @ldap_get_entries($this->conn, $result);
-        LDAPConn::stripCount($search);
-
-        if (isset($search)) {
-          // Object Exists
-            if (count($search) > 1) {  // 1 For LDAP count element, and 1 for actual object
-                // Duplicate Objects Found
-                die("FATAL: Call to ldapObject with non-unique DN.");
-            } else {
-                $this->object = $search[0];
-            }
+        $entries = @ldap_get_entries($this->conn, $result);
+        if ($entries === false) {
+            $this->object = null;
+            return false;
+        }
+        LDAPConn::stripCount($entries);
+        if (count($entries) > 1) {
+            throw new \Exception("FATAL: Call to ldapObject with non-unique DN.");
+        } else {
+            $this->object = $entries[0];
+            return true;
         }
     }
 


### PR DESCRIPTION
While writing tests for disbanding and recreating PI groups, I found that an LDAPEntry still thinks it exists after being deleted. This is because `$this->object` is not set back to `null` in `pullObject`.

rewrote `pullObject`:
* set `$this->object` to `null` if `ldap_read` or `ldap_get_entries` return false
* removed comment about "LDAP count element" because it's removed with `LDAP::stripCount`
* renamed `$search` to `$entries`
* replaced check for `isset($entries)` with `$entries === false`
* replaced `die()` with `throw new Exception`
* returned true on success