### PR TITLE
change getAttributes so that it can be used with setAttributes

### DIFF
--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -339,13 +339,23 @@ class LDAPEntry
     }
 
   /**
-   * Returns the entire objects attributes
+   * Returns the entire objects attributes in form suitable for setAttributes()
    *
    * @return array Array where keys are attributes
    */
     public function getAttributes()
     {
-        return $this->object;
+        $output = [];
+        foreach ($this->object as $key => $val) {
+            if (preg_match("/^[0-9]+$/", $key)) {
+                continue;
+            }
+            if ($key == "dn") {
+                continue;
+            }
+            $output[$key] = $val;
+        }
+        return $output;
     }
 
   /**


### PR DESCRIPTION
current output looks like this:
```json
{
    "objectclass": [
        "posixGroup",
        "top"
    ],
    "0": "objectclass",
    "gidnumber": [
        "39"
    ],
    "1": "gidnumber",
    "cn": [
        "pi_user5_org2_test"
    ],
    "2": "cn",
    "dn": "cn=pi_user5_org2_test,ou=pi_groups,dc=unityhpc,dc=test"
}
```

the index keys cause an error `Unknown attribute ni the data`, and the `dn` key causes an error `Add: undefined attribute type`.