### PR TITLE
write() error handling

### DIFF
--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -85,6 +85,7 @@ class LDAPEntry
     {
         return !is_null($this->object);
     }
+
   /**
    * Writes changes set in $mods array to the LDAP entry on the server.
    *

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -97,7 +97,6 @@ class LDAPEntry
         if ($this->mods == null) {
             return;
         }
-        $modsStr = json_encode($this->mods);
         if ($this->object == null) {
             $funcName = "ldap_add";
             ldap_add($this->conn, $this->dn, $this->mods);

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -106,14 +106,13 @@ class LDAPEntry
         }
         $errno = ldap_errno($this->conn);
         if ($errno != 0){
-            $errMsg = ldap_error($this->conn);
             $diagMsg = "";
             ldap_get_option($this->conn, LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagMsg);
             $wholeMsg = "LDAP error!\n" . json_encode(
                 [
                     "func" => $funcName,
                     "mods" => $this->mods,
-                    "ldap_error" => $errMsg,
+                    "ldap_error" => ldap_error($this->conn),
                     "LDAP_OPT_DIAGNOSTIC_MESSAGE" => $diagMsg,
                     "errno" => $errno,
                 ],

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -115,6 +115,7 @@ class LDAPEntry
                     "ldap_error" => ldap_error($this->conn),
                     "LDAP_OPT_DIAGNOSTIC_MESSAGE" => $diagMsg,
                     "errno" => $errno,
+                    "error_get_last" => error_get_last()
                 ],
                 JSON_PRETTY_PRINT
             );

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -2,6 +2,8 @@
 
 namespace PHPOpenLDAPer;
 
+use RuntimeException;
+
 /**
  * Class that represents one entry in an LDAP server
  * This class is not meant to be constructed outside the ldapConn class
@@ -86,6 +88,18 @@ class LDAPEntry
         return !is_null($this->object);
     }
 
+    private function getLdapErrorInfo()
+    {
+        $diagMsg = "";
+        ldap_get_option($this->conn, LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagMsg);
+        return [
+            "ldap_error" => ldap_error($this->conn),
+            "LDAP_OPT_DIAGNOSTIC_MESSAGE" => $diagMsg,
+            "errno" => ldap_errno($this->conn),
+            "error_get_last" => error_get_last()
+        ];
+    }
+
   /**
    * Writes changes set in $mods array to the LDAP entry on the server.
    *
@@ -104,22 +118,11 @@ class LDAPEntry
             $funcName = "ldap_mod_replace";
             ldap_mod_replace($this->conn, $this->dn, $this->mods);
         }
-        $errno = ldap_errno($this->conn);
-        if ($errno != 0){
-            $diagMsg = "";
-            ldap_get_option($this->conn, LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagMsg);
-            $wholeMsg = "LDAP error!\n" . json_encode(
-                [
-                    "func" => $funcName,
-                    "mods" => $this->mods,
-                    "ldap_error" => ldap_error($this->conn),
-                    "LDAP_OPT_DIAGNOSTIC_MESSAGE" => $diagMsg,
-                    "errno" => $errno,
-                    "error_get_last" => error_get_last()
-                ],
-                JSON_PRETTY_PRINT
-            );
-            throw new RuntimeException($wholeMsg);
+        $errorInfo = $this->getLdapErrorInfo();
+        if (intval($errorInfo["errno"]) != 0) {
+            $errorInfo["func"] = $funcName;
+            $errorInfo["mods"] = $this->mods;
+            throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
         $this->pullObject();  // Refresh $object array
         $this->mods = null;  // Reset Modifications Array to Null
@@ -128,20 +131,18 @@ class LDAPEntry
   /**
    * Deletes the entry (no need to call write())
    *
-   * @return bool True on success, False on failure
+   * @return void
+   * @throws RuntimeException if ldap_delete fails
    */
     public function delete()
     {
         if ($this->object == null) {
-            return true;
-        } else {
-            if (ldap_delete($this->conn, $this->dn)) {
-                $this->pullObject();
-                $this->mods = null;
-                return true;
-            } else {
-                return false;
-            }
+            return;
+        }
+        ldap_delete($this->conn, $this->dn);
+        $errorInfo = $this->getLdapErrorInfo();
+        if (intval($errorInfo["errno"]) != 0) {
+            throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
     }
 

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -92,7 +92,7 @@ class LDAPEntry
    * @return void
    * @throws RuntimeException if ldap_add / ldap_mod_replace fails
    */
-    public function write(): void
+    public function write()
     {
         if ($this->mods == null) {
             return;

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -95,7 +95,7 @@ class LDAPEntry
         return [
             "ldap_error" => ldap_error($this->conn),
             "LDAP_OPT_DIAGNOSTIC_MESSAGE" => $diagMsg,
-            "errno" => ldap_errno($this->conn),
+            "ldap_errno" => ldap_errno($this->conn),
             "error_get_last" => error_get_last()
         ];
     }
@@ -119,7 +119,7 @@ class LDAPEntry
             ldap_mod_replace($this->conn, $this->dn, $this->mods);
         }
         $errorInfo = $this->getLdapErrorInfo();
-        if ($errorInfo["errno"] != 0) {
+        if ($errorInfo["ldap_errno"] != 0) {
             $errorInfo["func"] = $funcName;
             $errorInfo["mods"] = $this->mods;
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
@@ -141,7 +141,7 @@ class LDAPEntry
         }
         ldap_delete($this->conn, $this->dn);
         $errorInfo = $this->getLdapErrorInfo();
-        if ($errorInfo["errno"] != 0) {
+        if ($errorInfo["ldap_errno"] != 0) {
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
     }

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -144,6 +144,7 @@ class LDAPEntry
         if ($errorInfo["ldap_errno"] != 0) {
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
+        $this->mods = null;
         $this->pullObject();
     }
 

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -144,6 +144,7 @@ class LDAPEntry
         if ($errorInfo["ldap_errno"] != 0) {
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
+        $this->pullObject();
     }
 
   /**

--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -119,7 +119,7 @@ class LDAPEntry
             ldap_mod_replace($this->conn, $this->dn, $this->mods);
         }
         $errorInfo = $this->getLdapErrorInfo();
-        if (intval($errorInfo["errno"]) != 0) {
+        if ($errorInfo["errno"] != 0) {
             $errorInfo["func"] = $funcName;
             $errorInfo["mods"] = $this->mods;
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
@@ -141,7 +141,7 @@ class LDAPEntry
         }
         ldap_delete($this->conn, $this->dn);
         $errorInfo = $this->getLdapErrorInfo();
-        if (intval($errorInfo["errno"]) != 0) {
+        if ($errorInfo["errno"] != 0) {
             throw new RuntimeException("LDAP error!\n" . json_encode($errorInfo, JSON_PRETTY_PRINT));
         }
     }


### PR DESCRIPTION
every single use of `LDAPEntry->write()` in the web portal is wrapped with a conditional on the success return value to raise an exception with a half assed error message. Instead, make `write()` throw its own exception with lots more information. Particularly useful is the `LDAP_OPT_DIAGNOSTIC_MESSAGE`, which would have helped me debugging https://github.com/hakasapl/phpopenldaper/pull/10. For example, when the `dn` attribute was causing `write` to fail, all I got was this:
```
ldap_add(): Add: Undefined attribute type
```

where now I would get this:
```
    "ldap_error": "Undefined attribute type",
    "LDAP_OPT_DIAGNOSTIC_MESSAGE": "dn: attribute type undefined",
    "errno": 17
```