### PR TITLE
fix for correctness

### DIFF
--- a/src/PHPOpenLDAPer/LDAPEntry.php
+++ b/src/PHPOpenLDAPer/LDAPEntry.php
@@ -419,11 +419,12 @@ class LDAPEntry
     }
 
   /**
-   * Returns the entire objects attributes
+   * Returns the entire objects attributes in form suitable for setAttributes()
    *
    * @return array Array where keys are attributes
    */
-    public function getAttributes() {
+    public function getAttributes(): array
+    {
         $has_mods = $this->mods != null;
         $has_object = $this->object != null;
         if (!$has_mods && !$has_object) {


### PR DESCRIPTION
These functions can't agree about how they should behave if there are pending modifications:
* `attributeValueExists`
    * ignores any pending modifications and use the value from `$this->object`
* `getAttribute`
    * ignores any pending modifications and use the value from `$this->object`
* `getAttributes`
    * ignores any pending modifications and use the value from `$this->object`
* `setAttribute`
    * updates the attribute in `$this->mods`
* `setAttributes`
    * discards any pending modifications and overwrites `$this->mods` entirely
    * `setAttributes` does not overwrite the entire array of attributes in `$this->object`, so it shouldn't do that to `$this->mods`
    * example where this is wrong:
        * `$this->object` has attributes `a`, `b`, and `c`
        * `$this->mods` has attributes `c` and `d`
        * `write(); setAttributes([c => ...]); write()` results in `$this->object` holding the `d` attribute
        * `setAttributes([c => ...]); write()` results in the `d` attribute being lost
* `appendAttribute`
    * merges `$this->object`, `$this->mods`, and the new value
    * in the case where the specified attribute is absent from `$this->mods`, `$this->object` is necessary
    * in the case where the specified attribute is *present* in `$this->mods` and is the result of another `appendAttribute`, the merge is technically correct but `$this->object` is unnecessary and confusing
    * in the case where the specified attribute is *present* in `$this->mods` and is the result of `setAttribute` or `removeAttributeEntryByValue`, this is wrong
        * example: attribute value is `[$foobar]`, then `setAttribute([])`, then `appendAttribute($barfoo)`
            * new value should be `[$barfoo]`
            * actual value is `[$foobar, $barfoo]`
* `removeAttributeEntryByValue`
    * ignores `$this->mods` and overwrites it using the value from `$this->object`

With this patch, all the above functions should take pending modifications into consideration and behave the same way as though `write()` were called first.